### PR TITLE
Generics

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -77,7 +77,7 @@ export const callFunctionByReference = (ref, args, variables, morphisms, name) =
             let type = candidateFunction.types[i];
             const condition = candidateFunction.conditions[i];
             const specificity = 'specificities' in candidateFunction ? candidateFunction.specificities[i] : 1;
-            let [typeScore, gt] = typeSatisfaction(args[i].type, type,genericTable);
+            let [typeScore, gt] = typeSatisfaction(args[i].type, type,genericTable, 0);
             genericTable = {...genericTable, ...gt};
             if (typeScore === 0) {
                 //Try to find a morphism path

--- a/interpreter.js
+++ b/interpreter.js
@@ -71,22 +71,14 @@ export const callFunctionByReference = (ref, args, variables, morphisms, name) =
         //For the conditions analysis
         variables.enterScope();
         const tempArgs = [...args];
-        const genericTable = {};
+        let genericTable = {};
         let score = 0;
         for (let i = 0 ; i < candidateFunction.types.length ; i ++ ) {
             let type = candidateFunction.types[i];
-            if (isGeneric(type)) {
-                const genericName = type.generic;
-                if (genericName in genericTable) {
-                    type = genericTable[genericName];
-                } else {
-                    genericTable[genericName] = args[i].type;
-                    variables.assignValue(genericName, genericTable[genericName]);
-                }
-            }
             const condition = candidateFunction.conditions[i];
             const specificity = 'specificities' in candidateFunction ? candidateFunction.specificities[i] : 1;
-            let typeScore = typeSatisfaction(args[i].type, type);
+            let [typeScore, gt] = typeSatisfaction(args[i].type, type,genericTable);
+            genericTable = {...genericTable, ...gt};
             if (typeScore === 0) {
                 //Try to find a morphism path
                 const path = morphisms.pathBetween(args[i].type, type);

--- a/notes/generics.txt
+++ b/notes/generics.txt
@@ -1,0 +1,16 @@
+There are two types of generics here
+
+f = {x:T, y:T} => ...
+
+and
+
+f = {x:(T,T)} => ...
+
+Cases:
+f = {x:T, xs: [T]}
+f = {x:(T,S), y:S}
+
+Matching can assign n generics, that happens in the type satisfaction function
+This should return a pair of (satisfaction:#, generics:[])
+
+These generics should be persisted between arguments but not cases unless the case is winning

--- a/notes/todo.txt
+++ b/notes/todo.txt
@@ -28,3 +28,4 @@
 - make morphisms take a from and to type so that functions that handle multiple different types can work, to stringify
 - get list subtypes by name like list[character] or tuple(#,#)
 - when signature defined with unknown types, we need to handle calling that function so that that type is assigned on call
+- a  = 3 //reads as =(_,a=3) since assignment regex doesn't accept spaces

--- a/types.js
+++ b/types.js
@@ -132,6 +132,10 @@ export const createTypeVar = (type) => {
     return createVar(type, primitives.TYPE);
 }
 
+export const createGeneric = (type, name) => {
+    return {...type, 'generic': name};
+}
+
 export const createError = (message) => {
     return createVar(message, primitives.ERROR);
 }
@@ -186,6 +190,8 @@ export const inferTypeFromString = (rawString, variables) => {
             return createTypedList(newType);
         }
     }
+
+    return createGeneric(primitives.ANY, string);
 
     return primitives.ANY;
 }
@@ -313,3 +319,9 @@ export const charListToJsString = (v) => {
 export const isAlias = (t) => {
     return 'alias' in t;
 }
+
+export const isGeneric = (t) => {
+    return 'generic' in t;
+}
+
+//Create function that given a type fills in a generic value for a generic so we don't have to search every time

--- a/vars.js
+++ b/vars.js
@@ -18,6 +18,15 @@ export class ScopedVars {
         this.scopes[this.depth][name] = value;
     }
 
+    deleteValue (name) {
+        for (let i = this.scopes.length - 1 ; i >= 0 ; i -- ) {
+            if (name in this.scopes[i]) {
+                delete this.scopes[i][name];
+                return;
+            }
+        }
+    }
+
     assignVariableUpScope (name, value) {
         this.scopes.forEach(scope => scope[name] = value);
     }
@@ -27,8 +36,7 @@ export class ScopedVars {
             return false;
         }
         for (let i = this.scopes.length - 1 ; i >= 0 ; i -- ) {
-            const scope = this.scopes[i];
-            if (name in scope) {
+            if (name in this.scopes[i]) {
                 return true;
             }
         }
@@ -37,9 +45,8 @@ export class ScopedVars {
 
     lookupValue (name) {
         for (let i = this.scopes.length - 1 ; i >= 0 ; i -- ) {
-            const scope = this.scopes[i];
-            if (name in scope) {
-                return scope[name];
+            if (name in this.scopes[i]) {
+                return this.scopes[i][name];
             }
         }
         throw "Unknown variable";
@@ -47,9 +54,8 @@ export class ScopedVars {
 
     getOrNull (name) {
         for (let i = this.scopes.length - 1 ; i >= 0 ; i -- ) {
-            const scope = this.scopes[i];
-            if (name in scope) {
-                return scope[name];
+            if (name in this.scopes[i]) {
+                return this.scopes[i][name];
             }
         }
 


### PR DESCRIPTION
This primarily adds working generics to the language and also has a few other little changes to the accuracy of the type system.

Generics are supported using unknown type variables.  They work in the cases:
```
f = {x:T, y:T} => ...
f = {x:T, y:[T]} => ...
f = {x:(T,T), y:T} => ...
f = {x:(T,U), y:U} => ...
```
and so on.  Generics are entered as type variables in the function body.  Currently, generics don't work with morphisms, meaning a `U` that can be morphed to a `T` won't satisfy a `T` generic.  This is up for debate.

This also makes nested type matching go a little deeper, in that a match of (number, [ANY]) will rank higher than a match of (number, ANY).  Generally, the deeper an ANY is nested, the more it is treated as an exact type match.