### PR TITLE
Added a handful of helper methods needed in AOC

### DIFF
--- a/builtins.js
+++ b/builtins.js
@@ -897,7 +897,6 @@ export const standardLib = [
     "all = {vs:[], mapper:fn} => (vs \\> (true,(mapper(@) & $)))",
     "any = {vs:[], mapper:fn} => (vs \\> (false, (mapper(@) | $)))",
     "reverse = {vs:[]} => (vs -> (get(vs, len(vs) - # - 1)))",
-    "is_numeric = {c:character} => (ord(c) >= 48 & ord(c) <= 57)",
     "first = {vs:[]} => (get(vs,0))",
     "last = {vs:[]} => (get(vs, len(vs) - 1))"
 ]


### PR DESCRIPTION
Adds a few text manipulation functions:
- `to_number`: uses the underlying JS `Number` constructor on a string.
- `is_numeric`: checks if a string is numeric.
- `replace`: given a haystack, needle, and replacement, using JS `replaceAll` to do a find and replace.
- `add` (for two characters): concatenates two characters into a string.

Adds the `first` and `last` function for getting the first and last elements from lists.

Adds `reverse` for lists, `all` for lists, which checks that all elements satisfy some given function, and `any`, which checks that at least one element satisfies a given function.

Also adds a very basic function (`read`) for reading a file into a list of strings, separated by newlines.