### PR TITLE
Adds monadic map/filter/reduce for arbitrary types

### DIFF
--- a/builtins.ts
+++ b/builtins.ts
@@ -239,13 +239,9 @@ export const builtins = {
 
       return res;
     }),
-    newFunction(
-      2,
-      [Primitives.ANY, Primitives.EXPRESSION],
-      ([item, expr], context) => {
-        return namedMonadicMap(item, expr, context, ["@", "#", "^"]);
-      },
-    ),
+    newFunction(2, [Primitives.ANY, Primitives.EXPRESSION], ([item, expr]) => {
+      return namedMonadicMap(item, expr, ["@", "#", "^"]);
+    }),
   ],
   "\\>": [
     newFunction(
@@ -1193,11 +1189,12 @@ const namedMap = (
 function namedMonadicMap(
   item: FeverVar,
   expression: FeverVar,
-  ctx: Context,
   varNames: string[],
 ) {
-  const variablesFromItem = dispatchFunction("to_monad", [item]);
+  const variablesFromItem = dispatchFunction("lift", [item]);
   const mappings = {};
+  // Probably need to separate named args from default case
+  // Also this assumes there is just one concrete failure case, true for optionals but not errors
   for (let i = 0; i < 3; i++) {
     if (variablesFromItem.value.length <= i) {
       // No monad mappings registered
@@ -1218,7 +1215,15 @@ function namedMonadicMap(
     result = evaluate(recreatedExpression);
   }
 
-  return dispatchFunction("from_monad", [result, item]);
+  return dispatchFunction("drop", [result, item]);
+}
+
+function namedMonadicFilter(
+  item: FeverVar,
+  expression: FeverVar,
+  varNames: string[],
+) {
+  const variablesFromItem = dispatchFunction("lift", [item]);
 }
 
 const namedReduce = (

--- a/examples/optionals.fv
+++ b/examples/optionals.fv
@@ -18,8 +18,8 @@ nullable = {v} => (maybe(v, not_null))
 // If a value is present, create an Optional of the provided function called on its value
 // -> = {empty(), _:fn} => empty()
 // -> = {o:Optional, lambda:fn} => (full(lambda(value(o))))
-lift = {empty()} => [passthrough(empty())]
-lift = {o:Optional} => ([value(o), empty()])
+lift = {empty()} => (([passthrough(empty())], empty()))
+lift = {o:Optional} => (([value(o), empty()], empty()))
 drop = {empty(), o: Optional} => (empty())
 drop = {v, o: Optional} => (full(v))
 // If a value is present and satisfies the provided condition, return the initial value

--- a/examples/optionals.fv
+++ b/examples/optionals.fv
@@ -16,8 +16,12 @@ not_null = {null} => false
 nullable = {v} => (maybe(v, not_null))
 
 // If a value is present, create an Optional of the provided function called on its value
--> = {empty(), _:fn} => empty()
--> = {o:Optional, lambda:fn} => (full(lambda(value(o))))
+// -> = {empty(), _:fn} => empty()
+// -> = {o:Optional, lambda:fn} => (full(lambda(value(o))))
+to_monad = {empty()} => [passthrough(empty())]
+to_monad = {o:Optional} => ([value(o)])
+from_monad = {empty(), o: Optional} => (empty())
+from_monad = {v, o: Optional} => (full(v))
 // If a value is present and satisfies the provided condition, return the initial value
 ~> = {empty(), _:fn} => empty()
 ~> = {o:Optional, lambda:fn} => (lambda(value(o)).?(o, empty()))

--- a/examples/optionals.fv
+++ b/examples/optionals.fv
@@ -18,10 +18,10 @@ nullable = {v} => (maybe(v, not_null))
 // If a value is present, create an Optional of the provided function called on its value
 // -> = {empty(), _:fn} => empty()
 // -> = {o:Optional, lambda:fn} => (full(lambda(value(o))))
-to_monad = {empty()} => [passthrough(empty())]
-to_monad = {o:Optional} => ([value(o)])
-from_monad = {empty(), o: Optional} => (empty())
-from_monad = {v, o: Optional} => (full(v))
+lift = {empty()} => [passthrough(empty())]
+lift = {o:Optional} => ([value(o), empty()])
+drop = {empty(), o: Optional} => (empty())
+drop = {v, o: Optional} => (full(v))
 // If a value is present and satisfies the provided condition, return the initial value
 ~> = {empty(), _:fn} => empty()
 ~> = {o:Optional, lambda:fn} => (lambda(value(o)).?(o, empty()))

--- a/notes/todo.txt
+++ b/notes/todo.txt
@@ -34,3 +34,5 @@ Also, since we don't split explicitly on assignment, assigning to higher order f
 User defined maps can't use default field names, confusing, ie. optional -> (@ * 2) would be nice but you need a full function
 Auto operations on tuples seems cool, but really causes a lot of problems
 Type expansion making objects way too big and redundant, store on either value or type
+
+Hmmm...auto defined types are being treated as lists?

--- a/types.ts
+++ b/types.ts
@@ -146,6 +146,10 @@ export function createCondition(
   return createVar([name, expr, specificity], Meta.CONDITION);
 }
 
+export function createMonadPassthrough(value: FeverVar) {
+  return createVar(value, createTypedTuple([Primitives.ANY], "PASSTHROUGH"));
+}
+
 const STRING = createTypedList(Primitives.CHARACTER, "STRING");
 const CONDITION = createTypedTuple(
   [STRING, Primitives.EXPRESSION, Primitives.NUMBER],
@@ -225,6 +229,10 @@ export const typeSatisfaction = (
     }
 
     return [weightedAnyType(depth), genericTable];
+  }
+
+  if (child.baseName !== parent.baseName) {
+    return [0, genericTable];
   }
 
   if (isAlias(parent)) {


### PR DESCRIPTION
Previously, types implementing any of the higher order function operators had to provide a function to call on the data.  This required specific handling for the type as well as defining a whole function, which is not required for list higher order functions.

This adds support for using monad enabled types directly against expressions when performing higher order functions.

Previous code looks like:
```js
 -> = {empty(), _:fn} => empty()
 -> = {o:Optional, lambda:fn} => (full(lambda(value(o))))
```

But by implementing the `to_monad` and `from_monad` functions for this type, all higher order functions can be performed via an expression rather than a full function.